### PR TITLE
Fix a bug with calculating the directory size

### DIFF
--- a/src/Commands/ImageCommands/DirectorySizeCommand.php
+++ b/src/Commands/ImageCommands/DirectorySizeCommand.php
@@ -30,13 +30,16 @@ class DirectorySizeCommand extends FileSystemCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $size = $this->fileSystem->getFileCount($this->rootDirectory);
+            $size = $this->fileSystem->getDirectorySize($this->rootDirectory);
+
+            // Covert the size to megabytes
+            $size = ($size / 1024) / 1024;
         } catch (Exception $exception) {
             $output->writeln('<error>An error has occurred: ' . $exception->getMessage() . '</error>');
             return FileSystemCommand::FAILURE;
         }
 
-        $output->writeln('<info>The size is of the images directory is ' . $size . '.</info>');
+        $output->writeln('<info>The size is of the images directory is ' . round($size) . 'MB.</info>');
 
         return FileSystemCommand::SUCCESS;
     }

--- a/src/Filesystem/Adapters/LocalAdapter.php
+++ b/src/Filesystem/Adapters/LocalAdapter.php
@@ -102,7 +102,7 @@ class LocalAdapter implements AdapterInterface
      */
     public function directorySize(string $path): int
     {
-        return (new SplFileInfo($path))->getSize();
+        return $this->getFolderSize($path);
     }
 
     /**
@@ -156,5 +156,21 @@ class LocalAdapter implements AdapterInterface
         rename($oldPath, $newPath);
 
         return new SplFileInfo($newPath);
+    }
+
+    /**
+     * Get the size of the specified folder
+     * @param  string  $path
+     * @return false|int
+     */
+    protected function getFolderSize(string $path)
+    {
+        $size = 0;
+
+        foreach (glob($path . '/*', GLOB_NOSORT) as $item) {
+            $size += is_file($item) ? filesize($item) : $this->getFolderSize($item);
+        }
+
+        return $size;
     }
 }

--- a/tests/Filesystem/Adapters/LocalAdapterTest.php
+++ b/tests/Filesystem/Adapters/LocalAdapterTest.php
@@ -12,10 +12,25 @@ use Tsc\CatStorageSystem\Tests\TestCase;
 
 class LocalAdapterTest extends TestCase
 {
+    /**
+     * The instance of the adapter.
+     *
+     * @var AdapterInterface|LocalAdapter
+     */
     protected AdapterInterface $adapter;
 
+    /**
+     * The root path for storing temp testing files.
+     *
+     * @var string
+     */
     protected string $path;
 
+    /**
+     * Create a new adapter and set the root path.
+     *
+     * @return void
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -119,14 +134,18 @@ class LocalAdapterTest extends TestCase
 
     public function test_it_can_get_the_size_of_a_directory()
     {
-        $fileName = $this->faker->word . '.txt';
-        $path = $this->path . '/' . $fileName;
+        $directoryName = $this->faker->word;
+        $directoryPath = $this->path . '/' . $directoryName;
 
-        $size = (new SplFileObject($path, 'w'))
+        $this->adapter->makeDirectory($directoryPath);
+
+        $fileName = $this->faker->word . '.txt';
+
+        $size = (new SplFileObject($directoryPath . '/' . $fileName, 'w'))
             ->fwrite('3 Sided Cube');
 
-        $this->assertIsInt($this->adapter->directorySize($path));
-        $this->assertSame($size, $this->adapter->directorySize($path));
+        $this->assertIsInt($this->adapter->directorySize($directoryPath));
+        $this->assertSame($size, $this->adapter->directorySize($directoryPath));
     }
 
     public function test_it_can_make_a_directory()


### PR DESCRIPTION
Fixed a bug where the `image:directory-size` was calling the wrong filesystem method. Also fixed an issue where the directory size calculation was returning the wrong value.